### PR TITLE
Add EDR profiles to ESDLs

### DIFF
--- a/tests/data/esdl/Norse Mythology EDR Profiles.esdl
+++ b/tests/data/esdl/Norse Mythology EDR Profiles.esdl
@@ -1,0 +1,385 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="d4643afe-3813-4981-8fcf-974ca7018b5b" description="" esdlVersion="v2303" name="Norse Mythology" version="7">
+  <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="93f5e505-817c-440e-81ea-7f011405eda0">
+    <quantityAndUnits xsi:type="esdl:QuantityAndUnits" id="e273ea15-2e93-4e37-a7e7-ab65f1a41810">
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="WATTHOUR" id="12c481c0-f81e-49b6-9767-90457684d24a" description="Energy in kWh" physicalQuantity="ENERGY" multiplier="KILO"/>
+    </quantityAndUnits>
+  </energySystemInformation>
+  <instance xsi:type="esdl:Instance" id="ad7d4261-f4f7-4c63-8935-8e26ebf09b2f" name="Main">
+    <area xsi:type="esdl:Area" name="Iceland" id="83dfdeaf-f885-462a-ac24-d3d3118c8f15">
+      <asset xsi:type="esdl:ElectricityCable" name="ElectricityCable_c27f" length="7012.8" id="c27fa894-f32c-4e6e-b396-bd85deb6aaf0">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="8019638b-ea51-4a66-9d6a-2d7cbb3c2afd" id="69e69ad6-c8c6-4e51-92a6-1baf4bfa2f83"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="dcf68219-bdf5-4e35-9053-8bbfbe8feee8" connectedTo="5e71413e-6c3c-491f-9aef-f7702dffc477"/>
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="-21.054267883300785" lat="64.26219288908568"/>
+          <point xsi:type="esdl:Point" lon="-21.035728454589847" lat="64.24892076874816"/>
+          <point xsi:type="esdl:Point" lon="-20.946121215820316" lat="64.25026318304684"/>
+          <point xsi:type="esdl:Point" lon="-20.93925476074219" lat="64.24220771909953"/>
+        </geometry>
+      </asset>
+      <asset xsi:type="esdl:ElectricityCable" name="ElectricityCable_5e94" length="4785.0" id="5e949943-7966-446e-9514-afe5f30668b6">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="8019638b-ea51-4a66-9d6a-2d7cbb3c2afd" id="ace3fa7f-b41f-4a47-9cc5-bd172900ad0d"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="dd64ab3d-c368-43f0-9311-c912106e87bb" connectedTo="7fd4562a-0345-4aa4-8723-01300f06eada"/>
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="-21.03916168212891" lat="64.27322328178597"/>
+          <point xsi:type="esdl:Point" lon="-20.940628051757816" lat="64.2779918168504"/>
+        </geometry>
+      </asset>
+      <asset xsi:type="esdl:ElectricityCable" name="ElectricityCable_acfb" length="2848.0" id="acfb0111-e7d6-42bd-a2b4-de555304c8e8">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="f5f4ce72-dc9d-4928-8780-c69655cfe4d6" id="c02a7041-0be1-41b7-ab0a-90e6dfff7169"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="34823af7-a4d9-4ae5-a715-bbab03bea4ac" connectedTo="5e71413e-6c3c-491f-9aef-f7702dffc477"/>
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="-20.91384887695313" lat="64.26681426554525"/>
+          <point xsi:type="esdl:Point" lon="-20.931358337402344" lat="64.24235691569335"/>
+        </geometry>
+      </asset>
+      <asset xsi:type="esdl:Pipe" length="5623.5" name="Pipe_2c4b" id="2c4b3b2f-264f-4027-ae2e-f3ec5cdc0bee">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="ca13a453-57d1-4a63-b933-ca63fe33af34" id="a4feae4e-b6bd-4a21-b415-002ddf7b5be0"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="1453f4b9-67eb-40b9-ad5b-2e17f4424e15" connectedTo="7b132b24-fb51-45a5-b56a-9f80670eaac7"/>
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="-21.10954284667969" lat="64.2586145181298"/>
+          <point xsi:type="esdl:Point" lon="-21.096153259277347" lat="64.24817495485091"/>
+          <point xsi:type="esdl:Point" lon="-21.044998168945316" lat="64.24832411924044"/>
+          <point xsi:type="esdl:Point" lon="-21.04019165039063" lat="64.23206046160136"/>
+        </geometry>
+      </asset>
+      <asset xsi:type="esdl:Pipe" length="11264.1" name="Pipe_d0f9" id="d0f9a4d9-2fbe-4c4e-83b7-dcd356ac49cf">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="f4126c2b-33ca-472f-b756-fe9894b03236" id="d72b05fd-fd21-436c-bef6-767c2c9f9de4"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="6cfe90b8-2d51-4b3a-b2f4-cef6e0742250" connectedTo="7b132b24-fb51-45a5-b56a-9f80670eaac7"/>
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="-20.854454040527347" lat="64.26562172629494"/>
+          <point xsi:type="esdl:Point" lon="-20.872650146484375" lat="64.25339522950755"/>
+          <point xsi:type="esdl:Point" lon="-20.983886718750004" lat="64.25443916611019"/>
+          <point xsi:type="esdl:Point" lon="-20.98800659179688" lat="64.24310288658496"/>
+          <point xsi:type="esdl:Point" lon="-21.033325195312504" lat="64.2393728308295"/>
+          <point xsi:type="esdl:Point" lon="-21.03469848632813" lat="64.23250821324537"/>
+        </geometry>
+      </asset>
+      <asset xsi:type="esdl:Pipe" length="12194.6" name="Pipe_5563" id="5563475e-dad4-4ec6-a480-25f29aa09211">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="ca13a453-57d1-4a63-b933-ca63fe33af34" id="624c451c-6da6-4941-9830-1e0068aa75fb"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="bea61cda-e8f3-462c-8abb-0ef46298dc81" connectedTo="6e2be093-7baa-47bb-a98c-6093188845e2"/>
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="-21.101989746093754" lat="64.25876362617463"/>
+          <point xsi:type="esdl:Point" lon="-21.096153259277347" lat="64.25533393752119"/>
+          <point xsi:type="esdl:Point" lon="-20.983886718750004" lat="64.25906183984983"/>
+          <point xsi:type="esdl:Point" lon="-20.880546569824222" lat="64.2577198529598"/>
+          <point xsi:type="esdl:Point" lon="-20.86200714111328" lat="64.26606893454861"/>
+        </geometry>
+      </asset>
+      <area xsi:type="esdl:Area" id="dd27f13b-6d1e-4532-9092-bf5240099570" name="Valhalla">
+        <geometry xsi:type="esdl:Polygon" CRS="WGS84">
+          <exterior xsi:type="esdl:SubPolygon">
+            <point xsi:type="esdl:Point" lon="-20.96843719482422" lat="64.24161092467241"/>
+            <point xsi:type="esdl:Point" lon="-21.076240539550785" lat="64.22474615860128"/>
+            <point xsi:type="esdl:Point" lon="-21.06731414794922" lat="64.1987572878947"/>
+            <point xsi:type="esdl:Point" lon="-20.834584960937505" lat="64.19243510075158"/>
+            <point xsi:type="esdl:Point" lon="-20.829734802246097" lat="64.23802988755861"/>
+          </exterior>
+        </geometry>
+        <asset xsi:type="esdl:Export" name="Export_06ca" power="120.0" id="06ca24ec-77f5-44fe-be5a-bf2a059e8654">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="dc76a962-0359-4f88-9774-054c81aa78f2" id="29ce99fd-0c4f-47ae-8e29-ab6c4041a400"/>
+          <geometry xsi:type="esdl:Point" lon="-20.901145935058597" lat="64.23429914733688"/>
+        </asset>
+        <asset xsi:type="esdl:Electrolyzer" name="Electrolyzer_41ac" technicalLifetime="2.0" id="41ac619a-f1c5-4d89-a6f7-e75a9783c189" power="80.0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="dc76a962-0359-4f88-9774-054c81aa78f2" id="a439cb30-d40f-498b-b6a7-e0cfcbda0752"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="f4e1f65a-98bd-482c-8fd1-56cd70d4b515" connectedTo="87d08281-78d2-40de-8da5-b0db15c03361"/>
+          <geometry xsi:type="esdl:Point" lon="-20.953330993652347" lat="64.2198191095311"/>
+          <costInformation xsi:type="esdl:CostInformation" id="ef1036b1-0496-4503-a174-026b9169f98e">
+            <investmentCosts xsi:type="esdl:SingleValue" id="78e6ccda-9b94-4e5a-a2bc-28e0ae50a51f" value="26.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="13b95d58-007b-4b0e-b358-782a24a9897b" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="0e94f850-fe14-42c2-996f-ad4f6dcc9b9a" value="62.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="567bbf5b-6606-42bb-a306-f24ffc052144" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:GasStorage" name="GasStorage_f713" capacity="1000.0" fillLevel="500.0" maxChargeRate="100.0" technicalLifetime="3.0" maxDischargeRate="200.0" id="f7138a43-41d8-4fa7-9504-ed340bc5205e">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="226ea9fb-b875-4091-b3e8-9d21786b30b7" id="584e6bd3-36ac-4540-b7d1-c6280785b9b9"/>
+          <geometry xsi:type="esdl:Point" lon="-20.99349975585938" lat="64.21683259218487"/>
+          <costInformation xsi:type="esdl:CostInformation" id="235ed47c-6a88-4d90-b10a-b4b0f7ab92ee">
+            <investmentCosts xsi:type="esdl:SingleValue" id="41e539ad-dace-4098-ae50-6deb7e409afb" value="100.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="4467313f-fcf3-4049-9c2a-53fe870c499d" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="acbd2711-9014-4e6f-8462-34358e799cbf" value="50.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="1b85ef70-6b17-4fa2-8a4d-e26a80f47665" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:HeatPump" name="HeatPump_4b33" technicalLifetime="2.0" id="4b33f488-b157-411a-ab02-7a0d43c154a3" power="10.0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="dc76a962-0359-4f88-9774-054c81aa78f2" id="2f90ec2a-9efc-4979-9d86-99202db07c29"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="bb1b80cd-bce7-467d-8e86-b8b0e8644ee6" connectedTo="7cd2a9f9-da85-4a0f-9c66-89376480ae39"/>
+          <port xsi:type="esdl:InPort" name="Waste heat inport" connectedTo="db89cb60-8609-4417-bdbe-a7704a734176" id="82d42ef9-7d32-4991-821c-62b03a751ccf"/>
+          <geometry xsi:type="esdl:Point" lon="-20.88912963867188" lat="64.22728399302186"/>
+          <costInformation xsi:type="esdl:CostInformation" id="acbf20d9-e15f-4b5b-ac0b-f1ebd44f1550">
+            <investmentCosts xsi:type="esdl:SingleValue" id="467c3336-f052-44cf-8ac8-130c0d755d9c" value="16.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="9e0d5847-d565-461a-b7f6-65bb18cbf680" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="ef041594-ad92-4c87-9346-05511bd25db8" value="15.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="93a93849-da7a-4d75-9607-7a6c6edfbea1" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:FuelCell" name="FuelCell_9121" technicalLifetime="3.0" id="91218656-3706-403a-909c-f67d14f8b40c" power="90.0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="226ea9fb-b875-4091-b3e8-9d21786b30b7" id="27e984b8-7414-46c7-9f73-5f089a3c7719"/>
+          <port xsi:type="esdl:OutPort" name="E Out" id="a02d8cc6-ea45-4bfe-91c0-1813995c5f34" connectedTo="5e71413e-6c3c-491f-9aef-f7702dffc477"/>
+          <port xsi:type="esdl:OutPort" name="H Out" id="33e09eff-3a6f-4ba0-aa52-7d3595aef6f8" connectedTo="7cd2a9f9-da85-4a0f-9c66-89376480ae39"/>
+          <geometry xsi:type="esdl:Point" lon="-20.916252136230472" lat="64.20667602226591"/>
+          <costInformation xsi:type="esdl:CostInformation" id="f4430dfa-b5e4-4491-971e-0a1276bb4428">
+            <investmentCosts xsi:type="esdl:SingleValue" id="5be5a662-55ce-4117-bf12-1072a6c2972d" value="60.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="bbf2fac1-240f-49b2-b9fe-c9aa248f6237" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="e5e20c91-0a64-4d08-b724-815dfa04d475" value="55.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="1ebb56e6-eb1b-41d9-9ba1-f0aced6b2731" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:PowerPlant" name="PowerPlant_7227" type="COMBINED_CYCLE_GAS_TURBINE" technicalLifetime="12.0" id="7227d20f-918c-4de1-b698-a40ba29e9bc7" power="100.0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="34ffa8ad-f971-4c52-bd72-461841ffd549" id="ec622226-8d89-4464-8147-c7eafea89ca5"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="c0ad56e3-3a83-46e9-8d2e-43cbd02e08c9" connectedTo="5e71413e-6c3c-491f-9aef-f7702dffc477"/>
+          <geometry xsi:type="esdl:Point" lon="-20.965690612792972" lat="64.22862745817535"/>
+          <costInformation xsi:type="esdl:CostInformation" id="b9d6a549-1643-4364-81d3-f66f13d39f12">
+            <investmentCosts xsi:type="esdl:SingleValue" id="bbd99afa-e6b8-43c5-938a-fe6a5de8a094" value="51.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="9919ad01-e8a3-4bdf-aedf-d3b699c195d9" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="2f08aa06-9279-4ba0-942a-b4696a56a186" value="55.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="a8cc8399-5739-42f0-af76-28eeaa493e2e" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:ElectricityNetwork" name="ElectricityNetwork_be51" id="be51458b-218f-46cb-af0b-315fc879b0f0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="a02d8cc6-ea45-4bfe-91c0-1813995c5f34 c0ad56e3-3a83-46e9-8d2e-43cbd02e08c9 dcf68219-bdf5-4e35-9053-8bbfbe8feee8 34823af7-a4d9-4ae5-a715-bbab03bea4ac" id="5e71413e-6c3c-491f-9aef-f7702dffc477"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="dc76a962-0359-4f88-9774-054c81aa78f2" connectedTo="29ce99fd-0c4f-47ae-8e29-ab6c4041a400 a439cb30-d40f-498b-b6a7-e0cfcbda0752 2f90ec2a-9efc-4979-9d86-99202db07c29"/>
+          <geometry xsi:type="esdl:Point" lon="-20.932731628417972" lat="64.23429914733688"/>
+        </asset>
+        <asset xsi:type="esdl:GasNetwork" name="Gas network" id="bbaf1227-a413-4017-8cf9-6462f1947084">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="1453f4b9-67eb-40b9-ad5b-2e17f4424e15 6cfe90b8-2d51-4b3a-b2f4-cef6e0742250" id="7b132b24-fb51-45a5-b56a-9f80670eaac7"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="34ffa8ad-f971-4c52-bd72-461841ffd549" connectedTo="ec622226-8d89-4464-8147-c7eafea89ca5 2582d2d0-24b7-4e82-a2df-d192cfe55fbe"/>
+          <geometry xsi:type="esdl:Point" lon="-21.03469848632813" lat="64.22056568851187"/>
+        </asset>
+        <asset xsi:type="esdl:HeatNetwork" name="HeatNetwork_07de" id="07de2a53-5a92-4eb3-835a-d89fde7cadbe">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="bb1b80cd-bce7-467d-8e86-b8b0e8644ee6 33e09eff-3a6f-4ba0-aa52-7d3595aef6f8" id="7cd2a9f9-da85-4a0f-9c66-89376480ae39"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="7a4a907e-331c-49e1-9630-75a50f5ce061" connectedTo="08332a70-84ef-43bb-8619-a1805dd8a52f"/>
+          <geometry xsi:type="esdl:Point" lon="-20.86750030517578" lat="64.20368808661304"/>
+        </asset>
+        <asset xsi:type="esdl:GasNetwork" name="Hydrogen network" id="649b8515-cf84-438d-8e74-1da6c5073b69">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="f4e1f65a-98bd-482c-8fd1-56cd70d4b515 832a041e-8e71-46bc-8945-69705d87ba0a" id="87d08281-78d2-40de-8da5-b0db15c03361"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="226ea9fb-b875-4091-b3e8-9d21786b30b7" connectedTo="584e6bd3-36ac-4540-b7d1-c6280785b9b9 27e984b8-7414-46c7-9f73-5f089a3c7719 509306f7-dd17-4597-8166-b7f8fa8854d0"/>
+          <geometry xsi:type="esdl:Point" lon="-20.973587036132812" lat="64.21011174971652"/>
+        </asset>
+        <asset xsi:type="esdl:GasDemand" name="Hydrogen demand" power="50.0" id="45fa1a43-8943-4d8f-8eba-bafbae17f974">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="226ea9fb-b875-4091-b3e8-9d21786b30b7" id="509306f7-dd17-4597-8166-b7f8fa8854d0">
+            <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="RvE_profiles_test" field="Industrie" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="a4c9b7f2-afd0-41d6-aa7f-c971d219f207" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+            </profile>
+          </port>
+          <geometry xsi:type="esdl:Point" lon="-20.97427368164063" lat="64.21952047229907"/>
+        </asset>
+        <asset xsi:type="esdl:GasConversion" name="Hydrogen generator" technicalLifetime="5.0" id="05058aad-f87e-4207-9118-e005a62a4004" power="100.0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="34ffa8ad-f971-4c52-bd72-461841ffd549" id="2582d2d0-24b7-4e82-a2df-d192cfe55fbe"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="832a041e-8e71-46bc-8945-69705d87ba0a" connectedTo="87d08281-78d2-40de-8da5-b0db15c03361"/>
+          <geometry xsi:type="esdl:Point" lon="-21.01341247558594" lat="64.20772172357896"/>
+          <costInformation xsi:type="esdl:CostInformation" id="500c86f2-be54-409a-8960-8316a8149dbf">
+            <investmentCosts xsi:type="esdl:SingleValue" id="a192a369-b8f5-484d-b456-e051ae6002d1" value="188.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="761e8aca-5cd1-4271-ab6e-a3c0b772611d" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="46394d97-7bb1-4403-b18f-d668c3c7bf89" value="12.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="5b76b520-c0cc-4b31-83e3-51e17a450b4a" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:HeatProducer" name="Waste heat" power="10.0" technicalLifetime="2.0" id="f1b99314-4b7c-4f6b-88f2-520f4617fcf6">
+          <port xsi:type="esdl:OutPort" name="Out" id="db89cb60-8609-4417-bdbe-a7704a734176" connectedTo="82d42ef9-7d32-4991-821c-62b03a751ccf"/>
+          <geometry xsi:type="esdl:Point" lon="-20.857200622558597" lat="64.22982159465025"/>
+          <costInformation xsi:type="esdl:CostInformation" id="f1909582-03bf-4d08-8089-6b4c0548a741">
+            <investmentCosts xsi:type="esdl:SingleValue" id="97abf1f5-2e52-4b9d-af64-6cc5266febfc" value="16.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="3638b024-9076-455c-9f4c-b1644ab99860" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="ef99b456-3431-49d2-9eb0-1bfd5f2d6c2a" value="15.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="986b29dc-081e-4ed5-9784-7d7d07ff2943" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_d3b9" power="10.0" id="d3b98f6d-abda-4f10-98fc-f9d86f77fbe4">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="7a4a907e-331c-49e1-9630-75a50f5ce061" id="08332a70-84ef-43bb-8619-a1805dd8a52f">
+            <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="RvE_profiles_test" field="Utiliteiten" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="c6eb8450-50f4-4c72-b7c7-1ce4c2d57be0" multiplier="10.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+            </profile>
+          </port>
+          <geometry xsi:type="esdl:Point" lon="-20.84587097167969" lat="64.20174575554563"/>
+        </asset>
+      </area>
+      <area xsi:type="esdl:Area" id="3c9f292f-d7a8-4f0b-b5a8-0b17dc6ca49e" name="Asgard">
+        <area xsi:type="esdl:Area" id="befa140e-ae38-4ac9-97c5-09376be5bbad" name="Midgard">
+          <geometry xsi:type="esdl:Polygon" CRS="WGS84">
+            <exterior xsi:type="esdl:SubPolygon">
+              <point xsi:type="esdl:Point" lon="-20.931015014648438" lat="64.26905013784292"/>
+              <point xsi:type="esdl:Point" lon="-20.946121215820316" lat="64.29690882007257"/>
+              <point xsi:type="esdl:Point" lon="-20.85617065429688" lat="64.30941372865048"/>
+              <point xsi:type="esdl:Point" lon="-20.78922271728516" lat="64.29854669036891"/>
+              <point xsi:type="esdl:Point" lon="-20.80020904541016" lat="64.26636706936117"/>
+            </exterior>
+          </geometry>
+          <asset xsi:type="esdl:WindTurbine" name="WindTurbine_6cb4" power="120.0" technicalLifetime="5.0" id="6cb408e6-ab0c-4d1e-91e8-497a9c1bb21c">
+            <port xsi:type="esdl:OutPort" name="Out" connectedTo="7fd4562a-0345-4aa4-8723-01300f06eada" id="78aa04bd-6e64-40f3-86b2-bab87cf3936e">
+              <profile xsi:type="esdl:InfluxDBProfile" startDate="2015-01-01T00:00:00.000000+0000" measurement="profile_kW_2015_Hub_north_160m" field="power_kW" database="edr-profiles" endDate="2015-12-31T23:00:00.000000+0000" id="116f2541-b32d-4031-8d4d-a4ca761bd997" port="443" host="edr-profiles.hesi.energy" filters="">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+              </profile>
+            </port>
+            <geometry xsi:type="esdl:Point" lon="-20.895996093750004" lat="64.294526289623"/>
+            <costInformation xsi:type="esdl:CostInformation" id="2e9f6223-d0a8-495a-a217-9a3942f22db0">
+              <investmentCosts xsi:type="esdl:SingleValue" id="482d61f7-ea77-4b4a-a811-62b22bc2b171" value="12.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="57ec3f75-71fe-4299-b621-43ed19123132" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+              </investmentCosts>
+              <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="c782cdd9-e36d-499b-b285-862e1b57a7b9" value="3.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="8b208543-8b4a-4988-be95-cf00ffe37ed2" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+              </variableOperationalAndMaintenanceCosts>
+            </costInformation>
+          </asset>
+          <asset xsi:type="esdl:Import" name="Import_56bb" power="40.0" technicalLifetime="1.0" id="56bba6e3-29ae-4b22-9005-111d03d240db">
+            <port xsi:type="esdl:OutPort" name="Out" id="6a09f018-deea-49c1-94dc-557a5afec0c4" connectedTo="7fd4562a-0345-4aa4-8723-01300f06eada"/>
+            <geometry xsi:type="esdl:Point" lon="-20.863037109375004" lat="64.28231259027915"/>
+            <costInformation xsi:type="esdl:CostInformation" id="60825dec-e151-4cc0-9d85-e8c15f9f302e">
+              <investmentCosts xsi:type="esdl:SingleValue" id="b7c8585b-b67e-4de9-a8e1-730e3e7d40e0" value="45.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="051818ef-c442-419a-ab2c-82477f0acb52" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+              </investmentCosts>
+              <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="d1b9c17d-21bd-4539-a4bf-0971707f589a" value="1.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="f2b2a2c9-4d8f-488f-9a12-8bd9cbd0832c" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+              </variableOperationalAndMaintenanceCosts>
+            </costInformation>
+          </asset>
+          <asset xsi:type="esdl:ElectricityNetwork" name="ElectricityNetwork_913c" id="913c7dac-c31f-46e3-b42d-2ed501a20be6">
+            <port xsi:type="esdl:InPort" name="In" connectedTo="78aa04bd-6e64-40f3-86b2-bab87cf3936e 6a09f018-deea-49c1-94dc-557a5afec0c4 dd64ab3d-c368-43f0-9311-c912106e87bb f0433555-3e3c-4650-83fb-1bdb8e291e86 e2593ac4-78be-431d-b420-1207d7d67ca1" id="7fd4562a-0345-4aa4-8723-01300f06eada"/>
+            <port xsi:type="esdl:OutPort" name="Out" id="f5f4ce72-dc9d-4928-8780-c69655cfe4d6" connectedTo="c02a7041-0be1-41b7-ab0a-90e6dfff7169 58194ed4-51ea-4086-abef-e804d11a98c1 4d8e6f38-6ea6-41ea-a08b-25394cb0ed96"/>
+            <geometry xsi:type="esdl:Point" lon="-20.913505554199222" lat="64.27426646921975"/>
+          </asset>
+          <asset xsi:type="esdl:GasNetwork" name="GasNetwork_0a42" id="0a426095-38cc-4b40-9cfc-bf44d6ff94f7">
+            <port xsi:type="esdl:InPort" name="In" connectedTo="bea61cda-e8f3-462c-8abb-0ef46298dc81" id="6e2be093-7baa-47bb-a98c-6093188845e2"/>
+            <port xsi:type="esdl:OutPort" name="Out" id="f4126c2b-33ca-472f-b756-fe9894b03236" connectedTo="d72b05fd-fd21-436c-bef6-767c2c9f9de4 d720f1c2-04d0-4bd6-b9a5-1fbe8d151427"/>
+            <geometry xsi:type="esdl:Point" lon="-20.853080749511722" lat="64.27024252904668"/>
+          </asset>
+          <asset xsi:type="esdl:PumpedHydroPower" name="PumpedHydroPower_eabf" capacity="2000.0" fillLevel="2000.0" maxChargeRate="100.0" technicalLifetime="2.0" maxDischargeRate="20.0" id="eabff8a3-a0bc-42da-a9c4-4d094cf2391a">
+            <port xsi:type="esdl:InPort" name="In" connectedTo="f5f4ce72-dc9d-4928-8780-c69655cfe4d6" id="58194ed4-51ea-4086-abef-e804d11a98c1"/>
+            <geometry xsi:type="esdl:Point" lon="-20.92552185058594" lat="64.29363278764076"/>
+            <costInformation xsi:type="esdl:CostInformation" id="9f61cb4a-50f3-413d-8e92-37b7aeba8b9a">
+              <investmentCosts xsi:type="esdl:SingleValue" id="b73b8cc9-3e22-4199-a954-278f7f76a207" value="10.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="dffcb87a-cfcb-4d41-87fc-6ff260d573f6" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+              </investmentCosts>
+              <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="ca417323-91c8-45ee-b13a-1aba3e072668" value="10.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="82bf3ae5-2daf-4ffe-a9ff-8cf27d250fe3" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+              </variableOperationalAndMaintenanceCosts>
+            </costInformation>
+          </asset>
+          <asset xsi:type="esdl:ElectricityDemand" name="ElectricityDemand_1e9e" power="100.0" id="1e9ec4ee-e457-4c3c-9957-a4700498bb46">
+            <port xsi:type="esdl:InPort" name="In" connectedTo="f5f4ce72-dc9d-4928-8780-c69655cfe4d6" id="4d8e6f38-6ea6-41ea-a08b-25394cb0ed96">
+              <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E4A" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="4cef88d1-43a7-4de6-b5a8-dd4388afa1a2" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+              </profile>
+            </port>
+            <geometry xsi:type="esdl:Point" lon="-20.87539672851563" lat="64.27098774740105"/>
+          </asset>
+          <asset xsi:type="esdl:PowerPlant" name="PowerPlant_2d4c" type="COMBINED_CYCLE_GAS_TURBINE" technicalLifetime="1.0" id="2d4c5a85-6765-4c54-9de6-8722256976ff" power="20.0">
+            <port xsi:type="esdl:InPort" name="In" connectedTo="f4126c2b-33ca-472f-b756-fe9894b03236" id="d720f1c2-04d0-4bd6-b9a5-1fbe8d151427"/>
+            <port xsi:type="esdl:OutPort" name="Out" id="f0433555-3e3c-4650-83fb-1bdb8e291e86" connectedTo="7fd4562a-0345-4aa4-8723-01300f06eada"/>
+            <geometry xsi:type="esdl:Point" lon="-20.852737426757816" lat="64.2781408202984"/>
+            <costInformation xsi:type="esdl:CostInformation" id="383a3e95-e07c-47ac-aba5-0cdaca638a75">
+              <investmentCosts xsi:type="esdl:SingleValue" id="63ed74c0-6008-49c7-b708-08bcb2f26b9c" value="12.0"/>
+              <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="01ddee26-80c4-4964-832b-e8ce113cfe3f" value="12.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="b962f944-536f-4cdc-82ac-99fe266fd3e0" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+              </variableOperationalAndMaintenanceCosts>
+            </costInformation>
+          </asset>
+          <asset xsi:type="esdl:PowerPlant" name="PowerPlant_4e1c" type="NUCLEAR_3RD_GENERATION" technicalLifetime="12.0" id="4e1cd004-da90-4135-8399-fb8c56dbdcb3" power="200.0">
+            <port xsi:type="esdl:InPort" name="In" id="776a35a4-ef22-40a0-b488-94815b1b201a"/>
+            <port xsi:type="esdl:OutPort" name="Out" id="e2593ac4-78be-431d-b420-1207d7d67ca1" connectedTo="7fd4562a-0345-4aa4-8723-01300f06eada"/>
+            <geometry xsi:type="esdl:Point" CRS="WGS84" lon="-20.87608337402344" lat="64.2918456968408"/>
+            <costInformation xsi:type="esdl:CostInformation" id="689c8129-5d71-47ad-9c8d-86d569f674f4">
+              <investmentCosts xsi:type="esdl:SingleValue" id="7a350f0d-7574-475d-a855-035c409ca4b5" value="20.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="9232171f-c4fb-4059-a1c2-743f072cd93f" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+              </investmentCosts>
+              <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="120193ee-d5f2-4275-8397-568e6b6b894c" value="20.0">
+                <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="49407259-0037-4260-a0db-1ce4ae1233be" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+              </variableOperationalAndMaintenanceCosts>
+            </costInformation>
+          </asset>
+        </area>
+        <geometry xsi:type="esdl:Polygon" CRS="WGS84">
+          <exterior xsi:type="esdl:SubPolygon">
+            <point xsi:type="esdl:Point" lon="-21.105079650878906" lat="64.25995646156042"/>
+            <point xsi:type="esdl:Point" lon="-21.18541717529297" lat="64.26085105429894"/>
+            <point xsi:type="esdl:Point" lon="-21.20086669921875" lat="64.29541976266103"/>
+            <point xsi:type="esdl:Point" lon="-21.144905090332035" lat="64.3039063130678"/>
+            <point xsi:type="esdl:Point" lon="-21.05667114257813" lat="64.2983977970889"/>
+            <point xsi:type="esdl:Point" lon="-21.038475036621097" lat="64.26547265526776"/>
+          </exterior>
+        </geometry>
+        <asset xsi:type="esdl:ElectricityNetwork" name="ElectricityNetwork_bf61" id="bf612234-bcde-40a1-8c6a-943acf8cefbb">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="9bd4851c-7b05-46eb-ae42-21eccc3b17f9 b7b65117-a9fd-4fe9-934d-1626a9939cfe" id="d6255891-64af-4424-8d7a-b1a0caa79c35"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="8019638b-ea51-4a66-9d6a-2d7cbb3c2afd" connectedTo="69e69ad6-c8c6-4e51-92a6-1baf4bfa2f83 ace3fa7f-b41f-4a47-9cc5-bd172900ad0d efd5ad97-7b65-4acc-8bfc-44fb181daa84 f937380b-3ab1-4e57-b30d-65d90f5b2d4d"/>
+          <geometry xsi:type="esdl:Point" lon="-21.06353759765625" lat="64.26770863618859"/>
+        </asset>
+        <asset xsi:type="esdl:GasNetwork" name="GasNetwork_6912" id="691233d5-19e0-4338-9b73-fe0ff2b31329">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="eeace68b-c6b6-498b-9980-356b6243e122" id="994cf723-3af6-4d4b-8347-292169d5d1c4"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="ca13a453-57d1-4a63-b933-ca63fe33af34" connectedTo="a4feae4e-b6bd-4a21-b415-002ddf7b5be0 624c451c-6da6-4941-9830-1e0068aa75fb 9b1b3014-be88-4e51-85d7-479a6ed2a42c"/>
+          <geometry xsi:type="esdl:Point" lon="-21.111946105957035" lat="64.26353465868937"/>
+        </asset>
+        <asset xsi:type="esdl:PVInstallation" name="PVInstallation_e36d" power="150.0" technicalLifetime="2.0" id="e36d17db-241b-4385-b479-b5e62eae095d">
+          <port xsi:type="esdl:OutPort" name="Out" connectedTo="d6255891-64af-4424-8d7a-b1a0caa79c35" id="9bd4851c-7b05-46eb-ae42-21eccc3b17f9">
+            <profile xsi:type="esdl:InfluxDBProfile" startDate="2015-01-01T00:00:00.000000+0000" measurement="profile_kW_2015_Hub_east_160m" field="power_kW" database="edr-profiles" endDate="2015-12-31T23:00:00.000000+0000" id="31b45d7f-e951-4321-9a5b-25bfae2d9bd1" multiplier="0.3" port="443" host="edr-profiles.hesi.energy" filters="">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+            </profile>
+          </port>
+          <geometry xsi:type="esdl:Point" lon="-21.061477661132816" lat="64.28737746326682"/>
+          <costInformation xsi:type="esdl:CostInformation" id="bff0b4ab-9959-4b26-9aa4-a2bf0dafadf9">
+            <investmentCosts xsi:type="esdl:SingleValue" id="34338b70-ca31-4b62-b610-b3a3793cd344" value="20.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="b52aa3a1-1af8-4a66-9ece-d8e526008848" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="67dde7d3-2a4b-45e6-b85d-a6e84d55eb9c" value="2.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="e7fda4c0-4631-43ba-be45-78be78af4d1e" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:ElectricityDemand" name="ElectricityDemand_928f" power="150.0" id="928f1a33-549d-4e45-86aa-bb2258458a67">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="8019638b-ea51-4a66-9d6a-2d7cbb3c2afd" id="efd5ad97-7b65-4acc-8bfc-44fb181daa84"/>
+          <geometry xsi:type="esdl:Point" lon="-21.046714782714844" lat="64.26770863618859"/>
+        </asset>
+        <asset xsi:type="esdl:PowerPlant" name="PowerPlant_4e99" type="COMBINED_CYCLE_GAS_TURBINE" technicalLifetime="10.0" efficiency="0.5" id="4e9941cd-3e92-4b52-bc66-5ca5e50ec16a" power="1000.0">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="ca13a453-57d1-4a63-b933-ca63fe33af34" id="9b1b3014-be88-4e51-85d7-479a6ed2a42c"/>
+          <port xsi:type="esdl:OutPort" name="Out" id="b7b65117-a9fd-4fe9-934d-1626a9939cfe" connectedTo="d6255891-64af-4424-8d7a-b1a0caa79c35"/>
+          <geometry xsi:type="esdl:Point" lon="-21.087913513183597" lat="64.26547265526776"/>
+          <costInformation xsi:type="esdl:CostInformation" id="19ae3d7c-5aeb-4429-a943-3d94b30e9851">
+            <investmentCosts xsi:type="esdl:SingleValue" id="15a70fe0-6bd4-4525-9128-e10696078e02" value="10.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="14e9ba15-f6ff-4480-840c-01c688b3207c" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="4e6be453-9010-456e-b61d-28c2a010b7cf" value="2.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="196564d6-6a6b-4b26-8088-52a62dc84070" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:Battery" name="Battery_0c0a" capacity="1000.0" fillLevel="500.0" maxChargeRate="10.0" technicalLifetime="1.0" maxDischargeRate="100.0" id="0c0a3807-db52-4e97-ac63-7ada2603a0a4">
+          <port xsi:type="esdl:InPort" name="In" connectedTo="8019638b-ea51-4a66-9d6a-2d7cbb3c2afd" id="f937380b-3ab1-4e57-b30d-65d90f5b2d4d"/>
+          <geometry xsi:type="esdl:Point" lon="-21.084136962890625" lat="64.27828982294201"/>
+          <costInformation xsi:type="esdl:CostInformation" id="8a6e1d2a-c33f-4bf5-ae63-1b27b74e8999">
+            <investmentCosts xsi:type="esdl:SingleValue" id="3703658f-f737-4a1c-a1a0-79857f35c75a" value="100.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="934cfee2-ce88-4956-bdf8-79e29cb30360" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="c67c7311-a277-4594-bb43-dba49d881fdc" value="10.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="84e0236f-bb17-4607-8ec6-69a2b6922ff2" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+        <asset xsi:type="esdl:Import" name="Import_d41d" power="100.0" technicalLifetime="1.0" id="d41de9ec-8142-4408-825e-c32a396526ad">
+          <port xsi:type="esdl:OutPort" name="Out" id="eeace68b-c6b6-498b-9980-356b6243e122" connectedTo="994cf723-3af6-4d4b-8347-292169d5d1c4"/>
+          <geometry xsi:type="esdl:Point" lon="-21.154861450195316" lat="64.28454720766985"/>
+          <costInformation xsi:type="esdl:CostInformation" id="09c113d1-0211-4946-9c83-5ff840620fce">
+            <investmentCosts xsi:type="esdl:SingleValue" id="56fbcede-ae93-41e0-bc7c-746ce56b9de7" value="10.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="5046b156-a562-4c6a-9875-0aebd920ea85" unit="EURO" description="Cost in EUR/MWh/yr" perMultiplier="MEGA" physicalQuantity="COST" perTimeUnit="YEAR"/>
+            </investmentCosts>
+            <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="edb4688f-bc77-4583-87da-6c917dd16997" value="1.0">
+              <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATTHOUR" id="323d590e-efe8-41fa-a0ce-3f289fe7622d" unit="EURO" description="Cost in EUR/MWh" perMultiplier="MEGA" physicalQuantity="COST"/>
+            </variableOperationalAndMaintenanceCosts>
+          </costInformation>
+        </asset>
+      </area>
+    </area>
+  </instance>
+</esdl:EnergySystem>

--- a/tests/data/esdl/TinyTest EDR Profiles.esdl
+++ b/tests/data/esdl/TinyTest EDR Profiles.esdl
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="51323171-8245-41e1-a0d0-3623fb34f3ce" description="" esdlVersion="v2303" name="TinyTest" version="4">
+  <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="97799044-b7b7-4256-8997-1a3287231c69">
+    <quantityAndUnits xsi:type="esdl:QuantityAndUnits" id="97fef304-ba54-4e6b-b90d-7dcd805e5b81">
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="WATTHOUR" id="12c481c0-f81e-49b6-9767-90457684d24a" description="Energy in kWh" physicalQuantity="ENERGY" multiplier="KILO"/>
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="WATT" id="e9405fc8-5e57-4df5-8584-4babee7cdf1a" description="Power in kW" physicalQuantity="POWER" multiplier="KILO"/>
+    </quantityAndUnits>
+  </energySystemInformation>
+  <instance xsi:type="esdl:Instance" id="924dc50d-e5dd-4388-8ec2-390485518d6a" name="Untitled instance">
+    <area xsi:type="esdl:Area" id="d89556f6-83e8-4493-81f6-9bd94ffd9646" name="Untitled area">
+      <asset xsi:type="esdl:ElectricityDemand" name="ElectricityDemand_43ec" id="43ec5a61-2172-4e11-ac45-0238c83a3393">
+        <port xsi:type="esdl:InPort" name="In" connectedTo="4ec3a3c0-3ef5-4cf4-b515-a476c70410db 9a8a362c-4ef9-4819-8dfa-9284597349b2 825d197b-d69d-4753-aa52-fb5843c7c5ff 9268c316-ca2d-4772-9548-50cd0d19a1e9" id="158afc5c-e4f6-4bd4-8d9d-44b566b58158">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="RvE_profiles_test" field="Utiliteiten" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="89ef7ea2-79db-4d2e-9c9a-34b46a7c392f" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lon="4.883422851562501" lat="52.281601868071434"/>
+      </asset>
+      <asset xsi:type="esdl:WindTurbine" name="WindTurbine_d4b9" power="5000.0" controlStrategy="3fc88737-c8e0-4b6d-ae5f-250d1a8cbbfd" id="d4b9814f-c2d5-4146-b36e-047fc494f9f3">
+        <port xsi:type="esdl:OutPort" name="Out" connectedTo="158afc5c-e4f6-4bd4-8d9d-44b566b58158" id="9268c316-ca2d-4772-9548-50cd0d19a1e9">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2023-10-01T00:00:00.000000+0000" measurement="tiny_test_profiles_csv" field="wind" database="energy_profiles" endDate="2023-10-03T23:00:00.000000+0000" id="a931c8ad-9ce9-484b-b050-4abcd7118447" multiplier="0.0" port="8086" host="http://10.30.2.1" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" description="" id="36f71006-8039-40dc-b124-79468a1e52a2"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lon="4.989166259765626" lat="52.243358395343456"/>
+        <costInformation xsi:type="esdl:CostInformation" id="d5392626-1995-43a0-8279-e5c7c1ae64cd">
+          <investmentCosts xsi:type="esdl:SingleValue" id="56f7761d-8447-46ff-a418-a583d16ab843" value="70.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATT" unit="EURO" id="b6cc6461-b0cf-48be-80ca-f068c78ec9d7" description="Cost in EUR/MW" perMultiplier="MEGA" physicalQuantity="COST"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:PVPanel" name="PVPanel_fb42" power="5000.0" controlStrategy="6efdb6a5-b984-485a-9afc-24d5a7beca83" id="fb42f805-5700-4e61-888e-b4e454c4df7a">
+        <port xsi:type="esdl:OutPort" name="Out" connectedTo="158afc5c-e4f6-4bd4-8d9d-44b566b58158" id="825d197b-d69d-4753-aa52-fb5843c7c5ff"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lon="4.901275634765625" lat="52.21265572004473"/>
+        <costInformation xsi:type="esdl:CostInformation" id="423634ca-decd-4103-9346-0ab0f8d3f258">
+          <investmentCosts xsi:type="esdl:SingleValue" id="b645a957-5593-4c3a-a0bf-fff8001e9420" value="50.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATT" unit="EURO" id="3cc76b5c-a29b-4de4-9823-fa9721810dc9" description="Cost in EUR/MW" perMultiplier="MEGA" physicalQuantity="COST"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:PowerPlant" name="PowerPlant_OCGT" maxLoad="100000000" id="13c73ee3-0162-4589-86b3-31e596c0f975" power="10000.0">
+        <port xsi:type="esdl:InPort" name="In" id="488787f4-15d9-41bb-a5d2-92241f044a83"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="9a8a362c-4ef9-4819-8dfa-9284597349b2" connectedTo="158afc5c-e4f6-4bd4-8d9d-44b566b58158"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lon="4.781799316406251" lat="52.22864058406609"/>
+        <costInformation xsi:type="esdl:CostInformation" id="00f32eda-ec1f-4450-a1e7-a959a464665e">
+          <investmentCosts xsi:type="esdl:SingleValue" id="708e5e31-987d-40bb-8217-6d0e02b69428" value="25.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATT" unit="EURO" id="19e0f63b-42bd-4021-9aeb-7c95a588b743" description="Cost in EUR/MW" perMultiplier="MEGA" physicalQuantity="COST"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:PowerPlant" name="PowerPlant_CCGT" maxLoad="400000000" id="828396cc-d505-47a7-8416-11c9588ff32e" power="5000.0">
+        <port xsi:type="esdl:InPort" name="In" id="e71ff9ca-5977-476f-83bc-a689003027c4"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="4ec3a3c0-3ef5-4cf4-b515-a476c70410db" connectedTo="158afc5c-e4f6-4bd4-8d9d-44b566b58158"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lon="4.801712036132813" lat="52.20844822057699"/>
+        <costInformation xsi:type="esdl:CostInformation" id="74485c89-476c-4388-a1da-808f5b404c4b">
+          <investmentCosts xsi:type="esdl:SingleValue" id="28e4e077-0265-4097-b109-f6c08e0051c0" value="40.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="WATT" unit="EURO" id="a2851468-f913-4dba-8c1d-b391f7e331f5" description="Cost in EUR/MW" perMultiplier="MEGA" physicalQuantity="COST"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+    </area>
+  </instance>
+  <services xsi:type="esdl:Services">
+    <service xsi:type="esdl:CurtailmentStrategy" id="3fc88737-c8e0-4b6d-ae5f-250d1a8cbbfd" energyAsset="d4b9814f-c2d5-4146-b36e-047fc494f9f3" name="CurtailmentStrategy for WindTurbine_d4b9" maxPower="50000000.0"/>
+    <service xsi:type="esdl:CurtailmentStrategy" id="6efdb6a5-b984-485a-9afc-24d5a7beca83" energyAsset="fb42f805-5700-4e61-888e-b4e454c4df7a" name="CurtailmentStrategy for PVPanel_fb42" maxPower="10000000.0"/>
+  </services>
+</esdl:EnergySystem>

--- a/tests/data/esdl/vehicle_charging_etc EDR Profiles.esdl
+++ b/tests/data/esdl/vehicle_charging_etc EDR Profiles.esdl
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="18ad2dce-9d0b-4614-93ac-6f959a03c1b6" description="" esdlVersion="v2303" name="Untitled EnergySystem" version="16">
+  <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="224db916-1e4f-4b08-8d09-acb1f6e60afe">
+    <quantityAndUnits xsi:type="esdl:QuantityAndUnits" id="630ab370-880b-4461-b11f-62dd795564d8">
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="eb07bccb-203f-407e-af98-e687656a221d" unit="JOULE" description="Energy in GJ" physicalQuantity="ENERGY" multiplier="GIGA"/>
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="WATTHOUR" id="12c481c0-f81e-49b6-9767-90457684d24a" description="Energy in kWh" physicalQuantity="ENERGY" multiplier="KILO"/>
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="WATT" id="e9405fc8-5e57-4df5-8584-4babee7cdf1b" description="Power in MW" physicalQuantity="POWER" multiplier="MEGA"/>
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="WATT" id="e9405fc8-5e57-4df5-8584-4babee7cdf1a" description="Power in kW" physicalQuantity="POWER" multiplier="KILO"/>
+    </quantityAndUnits>
+    <carriers xsi:type="esdl:Carriers" id="699691f6-cc23-446d-bc3e-ae677768c0e5">
+      <carrier xsi:type="esdl:ElectricityCommodity" name="E" id="c0d4f233-4552-4d35-a353-c4987b5fe9b5"/>
+    </carriers>
+  </energySystemInformation>
+  <instance xsi:type="esdl:Instance" id="54aa974a-5ceb-4fa9-b5d4-1321d3bf7ae3" name="Untitled Instance">
+    <area xsi:type="esdl:Area" id="e2e61938-640a-475c-91df-1bc9574628dc" name="Untitled Area">
+      <asset xsi:type="esdl:Transformer" name="TRAFO1" voltageSecundary="400.0" voltagePrimary="10000.0" id="af954d00-4675-4b1b-a8ec-832181ec2155" capacity="2200000.0">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="PrimIn" connectedTo="8b32d5e8-de18-4a23-b352-c93ac3545ea7" id="5a552a67-10c3-4d79-b13f-0f7f43c38df3"/>
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="SecOut" connectedTo="80611f56-d901-478d-af82-7f11dab14cff b2546c24-3598-4267-8199-95d675b790bb 75bffa32-f8be-4552-9e80-447b9a442eba" id="a2e8ed4b-e5bd-49fc-a169-d16c55510b70"/>
+        <geometry xsi:type="esdl:Point" lon="5.322591662406921" lat="51.868472482757866"/>
+      </asset>
+      <asset xsi:type="esdl:Transformer" name="TRAFO2" voltageSecundary="400.0" voltagePrimary="10000.0" id="448af1d3-c4bf-4229-bcae-d538115f95af" capacity="2200000.0">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="PrimIn" connectedTo="8b32d5e8-de18-4a23-b352-c93ac3545ea7" id="a11196dc-4c94-49b7-94a8-fd727726376b"/>
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="SecOut" connectedTo="519085a1-30d7-4754-bff4-1bdef2e18a7d 8d4be910-f154-4e4f-b7df-69ddd3a3133c 7b64523d-6dc4-44a7-8042-d761274f40fd" id="f8ddb205-9002-4e77-8cae-dd5d989ab1b4"/>
+        <geometry xsi:type="esdl:Point" lon="5.322580933570863" lat="51.86796896752792"/>
+      </asset>
+      <asset xsi:type="esdl:Transformer" name="TRAFO3" voltageSecundary="400.0" voltagePrimary="10000.0" id="124f44b1-56c6-40fa-9b5c-c9f73be3561b" capacity="1000000.0">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="PrimIn" connectedTo="8b32d5e8-de18-4a23-b352-c93ac3545ea7" id="801ceeac-b7c9-4e96-9dd0-7b9fe57fd2bb"/>
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="SecOut" connectedTo="2627fa5f-0839-43e2-96a5-cf9a810ed7db" id="69cc08ae-1012-4a50-ba4b-9035c1f43469"/>
+        <geometry xsi:type="esdl:Point" lon="5.322570204734802" lat="51.86753836465916"/>
+      </asset>
+      <asset xsi:type="esdl:EVChargingStation" name="EVChargingStations_1-6" power="600000.0" id="bcd4dcb6-7b3b-43a6-94d4-f5af8cefa688">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="a2e8ed4b-e5bd-49fc-a169-d16c55510b70" id="80611f56-d901-478d-af82-7f11dab14cff">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E1A" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="4f2b795e-52a3-4a82-a5eb-864f32334657" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322843790054322" lat="51.868608285147154"/>
+      </asset>
+      <asset xsi:type="esdl:EVChargingStation" name="EVChargingStations_7-12" power="600000.0" id="05ce6b38-b340-4c1a-bc88-a499955afd4f">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="a2e8ed4b-e5bd-49fc-a169-d16c55510b70" id="b2546c24-3598-4267-8199-95d675b790bb">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E1B" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="7e3d2598-bae5-450a-9cf4-1cb0a710b0a0" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322838425636292" lat="51.86847247100638"/>
+      </asset>
+      <asset xsi:type="esdl:EVChargingStation" name="EVChargingStations_13-18" power="600000.0" id="16e28fdf-5150-4638-ad44-03271516483e">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="a2e8ed4b-e5bd-49fc-a169-d16c55510b70" id="75bffa32-f8be-4552-9e80-447b9a442eba">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E1C" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="1b91936f-c1e6-4e70-ace5-1a7d1481dcc5" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322838425636292" lat="51.86833665309794"/>
+      </asset>
+      <asset xsi:type="esdl:EVChargingStation" name="EVChargingStations_19-24" power="600000.0" id="e61f7375-102f-4960-b0a8-caa1539b6c98">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="f8ddb205-9002-4e77-8cae-dd5d989ab1b4" id="519085a1-30d7-4754-bff4-1bdef2e18a7d">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E2A" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="d6e72298-38d0-47f7-b7d3-d72adc6169be" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322833061218262" lat="51.86811140796427"/>
+      </asset>
+      <asset xsi:type="esdl:EVChargingStation" name="EVChargingStations_25-30" power="600000.0" id="f28dd83d-3389-420c-adb7-7d8c0182b9c5">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="f8ddb205-9002-4e77-8cae-dd5d989ab1b4" id="8d4be910-f154-4e4f-b7df-69ddd3a3133c">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E3A" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="057250bc-d48c-4cfa-bb81-344a850df690" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322827696800233" lat="51.867972279086246"/>
+      </asset>
+      <asset xsi:type="esdl:EVChargingStation" name="EVChargingStations_31-36" power="600000.0" id="0493a4b3-cc5b-453b-bdfd-3374db4837e6">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="f8ddb205-9002-4e77-8cae-dd5d989ab1b4" id="7b64523d-6dc4-44a7-8042-d761274f40fd">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="G1A" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="9431b392-94de-40f8-8e63-a6953b458642" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322822332382203" lat="51.86783314809903"/>
+      </asset>
+      <asset xsi:type="esdl:GenericConsumer" name="Power_Locks-6" power="750000.0" id="9629cdb5-1131-45b3-93dc-7951a0d06af5">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="69cc08ae-1012-4a50-ba4b-9035c1f43469" id="2627fa5f-0839-43e2-96a5-cf9a810ed7db">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2018-12-31T23:00:00.000000+0000" measurement="NEDU" field="E4A" database="edr-profiles" endDate="2019-12-31T22:00:00.000000+0000" id="97e9b479-3bb6-4806-aa33-4ceb04a61be0" multiplier="100.0" port="443" host="https://edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="12c481c0-f81e-49b6-9767-90457684d24a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Point" lon="5.322822332382203" lat="51.86753505222947"/>
+      </asset>
+      <asset xsi:type="esdl:PVPark" name="SolarFarm" power="10000000.0" id="672f91b9-2ff5-4573-92b1-aabaee2ce5a7" surfaceArea="14449">
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="Out" id="b1207dd5-bf63-44a0-9dff-5715bf1b2d7f"/>
+        <geometry xsi:type="esdl:Polygon" CRS="WGS84">
+          <exterior xsi:type="esdl:SubPolygon">
+            <point xsi:type="esdl:Point" lon="5.323824048286708" lat="51.86877701783065"/>
+            <point xsi:type="esdl:Point" lon="5.323807959222867" lat="51.867209939558"/>
+            <point xsi:type="esdl:Point" lon="5.325148714543993" lat="51.86719006083598"/>
+            <point xsi:type="esdl:Point" lon="5.324730398883802" lat="51.868955919700106"/>
+          </exterior>
+        </geometry>
+      </asset>
+      <asset xsi:type="esdl:WindPark" name="Betuwe_Wind_Park" power="10800000.0" id="2290450a-653a-4eaf-b1b9-62e15066f006" numberOfTurbines="3" surfaceArea="925" type="WIND_ON_LAND">
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="Out" connectedTo="402befc5-60c6-43bf-8bcb-f01b228ed8c9 1d036d92-069d-4ed4-83bd-a00348ba6119" id="dc28295a-3ce9-4895-bf77-79d75d115024">
+          <profile xsi:type="esdl:InfluxDBProfile" startDate="2015-01-01T00:00:00.000000+0000" measurement="profile_kW_2015_Hub_east_160m" field="power_kW" database="edr-profiles" endDate="2015-12-31T23:00:00.000000+0000" id="b4f4b6ca-cf9a-49c6-8dea-7c60186b09d4" multiplier="0.8" port="443" host="edr-profiles.hesi.energy" filters="">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1a"/>
+          </profile>
+        </port>
+        <geometry xsi:type="esdl:Polygon" CRS="WGS84">
+          <exterior xsi:type="esdl:SubPolygon">
+            <point xsi:type="esdl:Point" lon="5.3223553228247775" lat="51.867259891337376"/>
+            <point xsi:type="esdl:Point" lon="5.322923803080966" lat="51.867249951988505"/>
+            <point xsi:type="esdl:Point" lon="5.32292648459158" lat="51.86704122515486"/>
+            <point xsi:type="esdl:Point" lon="5.322336552250284" lat="51.867051164549885"/>
+          </exterior>
+        </geometry>
+        <costInformation xsi:type="esdl:CostInformation"/>
+      </asset>
+      <asset xsi:type="esdl:Import" name="Import_from_Grid" power="100000000.0" id="97a3a2c2-c238-4e3f-9b21-83359add5ec2">
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="Out" connectedTo="1d036d92-069d-4ed4-83bd-a00348ba6119" id="29e68a49-3936-4612-8f6a-626863bf8b8a"/>
+        <geometry xsi:type="esdl:Point" lon="5.321534872055055" lat="51.86759798835163"/>
+        <costInformation xsi:type="esdl:CostInformation">
+          <marginalCosts xsi:type="esdl:SingleValue" id="d6632166-bb09-473c-a1cb-9f58f064bfe5" value="0.9" name="Import_97a3-MarginalCosts"/>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Export" name="Export_to_Grid" power="100000000.0" id="10e0231d-46dd-4ee7-82db-58cc3e7601cf">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="fbfb30f0-af34-41d9-83f2-a727f4971b6f" id="bced7fee-f8df-4143-bd78-520e6d900c87"/>
+        <geometry xsi:type="esdl:Point" lon="5.321529507637024" lat="51.867833169923514"/>
+        <costInformation xsi:type="esdl:CostInformation">
+          <marginalCosts xsi:type="esdl:SingleValue" id="fdc1be99-3146-4a44-9d9c-d7a0d74d207b" value="0.1" name="Export_10e0-MarginalCosts"/>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:ElectricityNetwork" name="Secundair (SAP)" id="cbb7e03a-9014-4687-859a-0a82ba4cff6a" capacity="5000000.0">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="dc28295a-3ce9-4895-bf77-79d75d115024 fbfb30f0-af34-41d9-83f2-a727f4971b6f" id="402befc5-60c6-43bf-8bcb-f01b228ed8c9"/>
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="Out" connectedTo="5a552a67-10c3-4d79-b13f-0f7f43c38df3 a11196dc-4c94-49b7-94a8-fd727726376b 801ceeac-b7c9-4e96-9dd0-7b9fe57fd2bb 1d036d92-069d-4ed4-83bd-a00348ba6119" id="8b32d5e8-de18-4a23-b352-c93ac3545ea7"/>
+        <geometry xsi:type="esdl:Point" lon="5.322183966636658" lat="51.867730485163094"/>
+      </asset>
+      <asset xsi:type="esdl:ElectricityNetwork" name="Primair (PAP)" id="28aa992e-39bb-41be-877f-64df096389d9" capacity="10000000.0">
+        <port xsi:type="esdl:InPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="In" connectedTo="dc28295a-3ce9-4895-bf77-79d75d115024 29e68a49-3936-4612-8f6a-626863bf8b8a 8b32d5e8-de18-4a23-b352-c93ac3545ea7" id="1d036d92-069d-4ed4-83bd-a00348ba6119"/>
+        <port xsi:type="esdl:OutPort" carrier="c0d4f233-4552-4d35-a353-c4987b5fe9b5" name="Out" connectedTo="bced7fee-f8df-4143-bd78-520e6d900c87 402befc5-60c6-43bf-8bcb-f01b228ed8c9" id="fbfb30f0-af34-41d9-83f2-a727f4971b6f"/>
+        <geometry xsi:type="esdl:Point" lon="5.32187283039093" lat="51.86773379757838"/>
+      </asset>
+    </area>
+  </instance>
+</esdl:EnergySystem>


### PR DESCRIPTION
Added profiles from EDR to ports of consumers (in-port) and some producers (out-port). 
Not sure if this was the intention, since the original files didn't have profiles associated with assets. 
The only one that DID have profiles was vehicle_charge_etc.esdl.

These are the new files:
- Norse Mythology EDR Profiles.esdl
- TinyTest EDR Profiles.esdl
- vehicle_charging_etc EDR Profiles.esdl

The mesido and EYE files didn't really make sense for the application.
Also I'm not sure if the profiles I added will balance well in the system. (It's a bit unclear how Power/Energy and scaling with Multipliers work with the profiles.) Fingers crossed!

Closes #8